### PR TITLE
Add formatWebsite utility

### DIFF
--- a/src/formatting.tsx
+++ b/src/formatting.tsx
@@ -167,6 +167,16 @@ export function formatDuration (iso8601?: string) {
   return unitCountsHuman.map(([unit, count]) => `${count} ${unit}`).join(', ');
 }
 
+export function formatWebsite (website: string | undefined, text?: string): (string | JSX.Element) {
+  if (!website) {
+    return EMPTY_FIELD;
+  }
+
+  return (
+    <a href={website} rel='noopener noreferrer' target='_blank'>{text || website}</a>
+  );
+}
+
 export function stripNonAlpha (str?: string | null) {
   if (str === undefined || str === null) {
     return '';

--- a/test/formatting.test.js
+++ b/test/formatting.test.js
@@ -215,4 +215,19 @@ describe('formatting', () => {
     expect(parsedCaseNote[3].type).toBe('br');
     expect(parsedCaseNote[4]).toBe('hello');
   });
+
+  it('Correctly formats a website', () => {
+    const website = 'https://www.mighty.com'
+      , innerText = 'innerText';
+
+    expect(util.formatWebsite(undefined)).toBe('--');
+
+    const formattedWebsite = util.formatWebsite(website)
+    expect(formattedWebsite.props.href).toBe(website);
+    expect(formattedWebsite.props.children).toBe(website);
+
+    const formattedWebsiteWithText = util.formatWebsite(website, innerText);
+    expect(formattedWebsiteWithText.props.href).toBe(website);
+    expect(formattedWebsiteWithText.props.children).toBe(innerText);
+  });
 });


### PR DESCRIPTION
Adding a utility I used in a recent PR, which I said I would replace next time we bump `mighty-justice/utils`