### PR TITLE
More robust phone number formatting

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@ import Decimal from 'decimal.js';
 
 export const EMPTY_FIELD = '--';
 
+export const TEMPLATE_CHAR = '#';
+
 export const DATE_FORMATS: { [key: string]: string } = {
   date: 'MM/DD/YY',
   date_value: 'YYYY-MM-DD',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,6 @@ import Decimal from 'decimal.js';
 
 export const EMPTY_FIELD = '--';
 
-export const TEMPLATE_CHAR = '#';
-
 export const DATE_FORMATS: { [key: string]: string } = {
   date: 'MM/DD/YY',
   date_value: 'YYYY-MM-DD',

--- a/src/formatting.tsx
+++ b/src/formatting.tsx
@@ -46,16 +46,33 @@ export function formatFullName (firstName?: string, lastName?: string) {
 }
 
 export function formatPhoneNumber (input?: string | null) {
-  // check phone number not already formatted
-  const phoneNumber = input && input.match(/\d/g);
+  if (input === undefined || input === null || input === '') { return EMPTY_FIELD }
 
-  if (phoneNumber) {
-    const unformattedNumber = phoneNumber.join('');
+  const phoneNumbers = input.match(/\d/g) || []
+    , phoneNotNumbers = input.match(/[^0-9\-\(\)]/g) || []
+    , PHONE_FORMATS: { [key: number]: string } = {
+      12: '+## (###) ###-####',
+      11: '+# (###) ###-####',
+      10: '(###) ###-####',
+      7: '###-####',
+    };
 
-    // tslint:disable-next-line no-magic-numbers
-    return `(${unformattedNumber.slice(0, 3)}) ${unformattedNumber.slice(3, 6)}-${unformattedNumber.slice(6, 10)}`;
+  if (phoneNotNumbers.length) {
+    return input;
   }
-  return EMPTY_FIELD;
+
+  if (phoneNumbers.length in PHONE_FORMATS) {
+    const phoneNumbersReverse = phoneNumbers.reverse()
+      , format = PHONE_FORMATS[phoneNumbers.length]
+
+    return format
+      .split('')
+      .map(char => (char === '#') ? phoneNumbersReverse.pop() : char)
+      .join('')
+      ;
+  }
+
+  return input;
 }
 
 export function formatDate (value?: string | null, dateFormat = DATE_FORMATS.date) {

--- a/src/formatting.tsx
+++ b/src/formatting.tsx
@@ -179,7 +179,7 @@ export function mapBooleanToText (bool?: boolean | null, {mapUndefinedToNo} = {m
 
 export function formatMoneyInput (value?: null | number | string) {
   if (!hasStringOrNumberContent(value)) { return value; }
-  return value && numeral(value).value();
+  return numeral(value).value();
 }
 
 export function formatDuration (iso8601?: null | string) {

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -44,11 +44,17 @@ describe('formatting', () => {
   it('Correctly formats a phone number', () => {
     expect(util.formatPhoneNumber(null)).toBe('--');
     expect(util.formatPhoneNumber(undefined)).toBe('--');
-    expect(util.formatPhoneNumber('asdf')).toBe('--');
+    expect(util.formatPhoneNumber('5')).toBe('5');
+    expect(util.formatPhoneNumber('8675309')).toBe('867-5309');
     expect(util.formatPhoneNumber('5558675309')).toBe('(555) 867-5309');
     expect(util.formatPhoneNumber('(555)-867-5309')).toBe('(555) 867-5309');
     expect(util.formatPhoneNumber('(555)-8675309')).toBe('(555) 867-5309');
     expect(util.formatPhoneNumber('555-867-5309')).toBe('(555) 867-5309');
+    expect(util.formatPhoneNumber('867-5309')).toBe('867-5309');
+    expect(util.formatPhoneNumber('867-5309 ext. 4')).toBe('867-5309 ext. 4');
+    expect(util.formatPhoneNumber('Call main office')).toBe('Call main office');
+    expect(util.formatPhoneNumber('+2111 (555)-867-5309')).toBe('+2111 (555)-867-5309');
+    expect(util.formatPhoneNumber('125558675309')).toBe('+12 (555) 867-5309');
   });
 
   it('Correctly formats a name when passed an object', () => {

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -81,13 +81,13 @@ describe('formatting', () => {
     expect(util.getOrDefault('Hello')).toBe('Hello');
     expect(util.getOrDefault('Hello                     ')).toBe('Hello');
     expect(util.getOrDefault(123)).toBe(123);
+    expect(util.getOrDefault(0)).toBe(0);
   });
 
-  it('Correctly displays default value when a falsy value passed', () => {
+  it('Correctly displays default value when an empty value is passed', () => {
     expect(util.getOrDefault(null)).toBe('--');
     expect(util.getOrDefault(undefined)).toBe('--');
     expect(util.getOrDefault('')).toBe('--');
-    expect(util.getOrDefault(0)).toBe('--');
     expect(util.getOrDefault(' ')).toBe('--');
     expect(util.getOrDefault('                              ')).toBe('--');
   });
@@ -141,6 +141,7 @@ describe('formatting', () => {
     expect(util.formatMoneyInput('1,222.00')).toBe(1222);
     expect(util.formatMoneyInput(null)).toBe(null);
     expect(util.formatMoneyInput(undefined)).toBe(undefined);
+    expect(util.formatMoneyInput('')).toBe('');
     expect(util.formatMoneyInput('123')).toBe(123);
     expect(util.formatMoneyInput('5,757.57')).toBe(5757.57);
     expect(util.formatMoneyInput('123,456,789.99')).toBe(123456789.99);


### PR DESCRIPTION
## Phone number formatting

1. Recognize more phone numbers formats
2. Never hide data you don't understand or recognize

![image](https://user-images.githubusercontent.com/796717/53436401-25638680-39c9-11e9-9037-34945b8ae14f.png)

# Other
- Create mostly internal `canReplaceSymbols`, `replaceSymbolsWithChars` formatting helpers
- Create `hasStringContent` helper that correctly identifies `'  '` as empty
- Create `hasStringOrNumberContent` that correctly identifies `0` as non-empty