### PR TITLE
Allow Guarded containers to be ReactNode, not only ComponentClass

### DIFF
--- a/src/containers.tsx
+++ b/src/containers.tsx
@@ -16,7 +16,7 @@ export interface IGuardedContainerProps {
   isGuarded: boolean;
 }
 
-export function createDisabledContainer (WrappedComponent: React.ReactNode): React.ReactNode {
+export function createDisabledContainer (WrappedComponent:  React.ComponentType<any>): React.ReactNode {
   @observer
   class DisabledContainer extends Component<IDisabledContainerProps> {
     public static displayName = `DisabledContainer(${getDisplayName(WrappedComponent)})`;
@@ -45,7 +45,7 @@ export function createDisabledContainer (WrappedComponent: React.ReactNode): Rea
 export function createGuardedContainer ({ isGuarded, enabledComponent, disabledComponent }: IGuardedContainerProps): React.ComponentClass {
   @observer
   class GuardedContainer extends Component {
-    private readonly GuardedComponent: React.ReactNode;
+    private readonly GuardedComponent: any;
     public static displayName = `GuardedContainer(${getDisplayName(enabledComponent)})`;
 
     public constructor (props: any) {
@@ -59,7 +59,7 @@ export function createGuardedContainer ({ isGuarded, enabledComponent, disabledC
     }
 
     public render () {
-      return <this.GuardedComponent {...this.props} />;
+      return <this.GuardedComponent {...this.props as any} />;
     }
   }
 

--- a/src/containers.tsx
+++ b/src/containers.tsx
@@ -59,7 +59,7 @@ export function createGuardedContainer ({ isGuarded, enabledComponent, disabledC
     }
 
     public render () {
-      return <this.GuardedComponent {...this.props as any} />;
+      return <this.GuardedComponent {...this.props} />;
     }
   }
 

--- a/src/containers.tsx
+++ b/src/containers.tsx
@@ -11,12 +11,12 @@ export interface IDisabledContainerProps {
 }
 
 export interface IGuardedContainerProps {
-  disabledComponent: React.ComponentClass;
-  enabledComponent: React.ComponentClass;
+  disabledComponent: React.ReactNode;
+  enabledComponent: React.ReactNode;
   isGuarded: boolean;
 }
 
-export function createDisabledContainer (WrappedComponent: React.ComponentClass<any>): React.ComponentClass {
+export function createDisabledContainer (WrappedComponent: React.ReactNode): React.ReactNode {
   @observer
   class DisabledContainer extends Component<IDisabledContainerProps> {
     public static displayName = `DisabledContainer(${getDisplayName(WrappedComponent)})`;
@@ -45,7 +45,7 @@ export function createDisabledContainer (WrappedComponent: React.ComponentClass<
 export function createGuardedContainer ({ isGuarded, enabledComponent, disabledComponent }: IGuardedContainerProps): React.ComponentClass {
   @observer
   class GuardedContainer extends Component {
-    private readonly GuardedComponent: React.ComponentClass;
+    private readonly GuardedComponent: React.ReactNode;
     public static displayName = `GuardedContainer(${getDisplayName(enabledComponent)})`;
 
     public constructor (props: any) {

--- a/src/containers.tsx
+++ b/src/containers.tsx
@@ -16,7 +16,7 @@ export interface IGuardedContainerProps {
   isGuarded: boolean;
 }
 
-export function createDisabledContainer (WrappedComponent:  React.ComponentType<any>): React.ReactNode {
+export function createDisabledContainer (WrappedComponent: React.ComponentType<any>): React.ReactNode {
   @observer
   class DisabledContainer extends Component<IDisabledContainerProps> {
     public static displayName = `DisabledContainer(${getDisplayName(WrappedComponent)})`;


### PR DESCRIPTION
Fixes this restriction:
![Screen Shot 2019-04-01 at 9 58 37 AM](https://user-images.githubusercontent.com/1119991/55333188-c6c87700-5464-11e9-9723-a2ac79449be5.png)
![Screen Shot 2019-04-01 at 9 58 48 AM](https://user-images.githubusercontent.com/1119991/55333189-c6c87700-5464-11e9-9d2b-bab43ea631f8.png)
