### PR TITLE
Rework dependencies to match mobx-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "index.js"
   ],
   "peerDependencies": {
+    "lodash": "^4.0.0",
     "mobx": "^4.0.0 || ^5.0.0",
     "mobx-react": "^5.0.0",
     "react": "^16.0.0"
@@ -103,6 +104,7 @@
     "gitbook-plugin-search-plus": "^1.0.4-alpha-3",
     "jest": "^24.1.0",
     "jest-environment-jsdom": "^24.0.0",
+    "lodash": "4.17.11",
     "mobx": "^4.9.4",
     "mobx-react": "^5.4.3",
     "np": "^4.0.2",
@@ -126,7 +128,6 @@
     "decimal.js": "^10.1.1",
     "html-react-parser": "0.6.1",
     "iso8601-duration": "^1.1.7",
-    "lodash": "4.17.11",
     "moment": "^2.24.0",
     "numeral": "^2.0.6"
   }

--- a/package.json
+++ b/package.json
@@ -68,15 +68,9 @@
     "index.js"
   ],
   "peerDependencies": {
-    "classnames": "2",
-    "date-fns": "1",
-    "html-react-parser": "0",
-    "iso8601-duration": "1",
-    "lodash": "4",
-    "mobx": "4-5",
-    "mobx-react": "5",
-    "numeral": "2",
-    "react": "16"
+    "mobx": "^4.0.0 || ^5.0.0",
+    "mobx-react": "^5.0.0",
+    "react": "^16.0.0"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"
@@ -109,7 +103,8 @@
     "gitbook-plugin-search-plus": "^1.0.4-alpha-3",
     "jest": "^24.1.0",
     "jest-environment-jsdom": "^24.0.0",
-    "lodash": "4.17.11",
+    "mobx": "^4.9.4",
+    "mobx-react": "^5.4.3",
     "np": "^4.0.2",
     "numeral": "^2.0.6",
     "react": "16.8.3",
@@ -131,8 +126,7 @@
     "decimal.js": "^10.1.1",
     "html-react-parser": "0.6.1",
     "iso8601-duration": "^1.1.7",
-    "mobx": "^4",
-    "mobx-react": "^5",
+    "lodash": "4.17.11",
     "moment": "^2.24.0",
     "numeral": "^2.0.6"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4971,7 +4971,7 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
-mobx-react@^5:
+mobx-react@^5.4.3:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-5.4.3.tgz#6709b7dd89670c40e9815914ac2ca49cc02bfb47"
   integrity sha512-WC8yFlwvJ91hy8j6CrydAuFteUafcuvdITFQeHl3LRIf5ayfT/4W3M/byhEYD2BcJWejeXr8y4Rh2H26RunCRQ==
@@ -4979,7 +4979,7 @@ mobx-react@^5:
     hoist-non-react-statics "^3.0.0"
     react-lifecycles-compat "^3.0.2"
 
-mobx@^4:
+mobx@^4.9.4:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-4.9.4.tgz#bb37a0e4e05f0b02be89ced9d23445cad73377ad"
   integrity sha512-RaEpydw7D1ebp1pdFHrEMZcLk4nALAZyHAroCPQpqLzuIXIxJpLmMIe5PUZwYHqvlcWL6DVqDYCANZpPOi9iXA==


### PR DESCRIPTION
The goal of this is to widen our mobx compatibilities. To do this, I looked at how `mobx-react` writes their package.json. They only include libraries in dependencies if the parent would not have them. This differs from our previous strategy of including wide ranges in dependencies.

Based on https://github.com/mobxjs/mobx-react/blob/master/package.json