### PR TITLE
formatAddressMultiline should output 2 lines not 3

### DIFF
--- a/src/formatting.tsx
+++ b/src/formatting.tsx
@@ -302,5 +302,5 @@ export function formatAddress (address?: IAddress | null) {
 }
 
 export function formatAddressMultiline (address?: IAddress | null) {
-  return parser(formatAddress(address).replace(/, /g, '<br/>'));
+  return parser(formatAddress(address).replace(/, /, '<br/>'));
 }

--- a/src/formatting.tsx
+++ b/src/formatting.tsx
@@ -302,5 +302,5 @@ export function formatAddress (address?: IAddress | null) {
 }
 
 export function formatAddressMultiline (address?: IAddress | null) {
-  return parser(formatAddress(address).replace(/, /, '<br/>'));
+  return parser(formatAddress(address).replace(', ', '<br/>'));
 }

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -256,26 +256,35 @@ describe('formatting', () => {
 
   it('Correctly formats an address', () => {
     expect(util.formatAddress(null)).toBe('--, --, -- --');
-    expect(util.formatAddress({address1: '123 Fake St', address2: 'Apt 1-D', city: 'New York', state: 'NY', zip_code: '10001'})).toBe('123 Fake St Apt 1-D, New York, NY 10001');
-    expect(util.formatAddress({address1: '', address2: 'Apt 1-D', city: 'New York', state: 'NY', zip_code: '10001'})).toBe('-- Apt 1-D, New York, NY 10001');
-    expect(util.formatAddress({address1: '123 Fake St', address2: '', city: 'New York', state: 'NY', zip_code: '10001'})).toBe('123 Fake St, New York, NY 10001');
-    expect(util.formatAddress({address1: '123 Fake St', address2: 'Apt 1-D', city: '', state: 'NY', zip_code: '10001'})).toBe('123 Fake St Apt 1-D, --, NY 10001');
-    expect(util.formatAddress({address1: '123 Fake St', address2: 'Apt 1-D', city: 'New York', state: '', zip_code: '10001'})).toBe('123 Fake St Apt 1-D, New York, -- 10001');
-    expect(util.formatAddress({address1: '123 Fake St', address2: 'Apt 1-D', city: 'New York', state: 'NY', zip_code: ''})).toBe('123 Fake St Apt 1-D, New York, NY --');
+    expect(util.formatAddress(
+      {address1: '123 Fake St', address2: 'Apt 1-D', city: 'New York', state: 'NY', zip_code: '10001'}),
+    ).toBe('123 Fake St Apt 1-D, New York, NY 10001');
+    expect(util.formatAddress(
+      {address1: '', address2: 'Apt 1-D', city: 'New York', state: 'NY', zip_code: '10001'}),
+    ).toBe('-- Apt 1-D, New York, NY 10001');
+    expect(util.formatAddress(
+      {address1: '123 Fake St', address2: '', city: 'New York', state: 'NY', zip_code: '10001'}),
+    ).toBe('123 Fake St, New York, NY 10001');
+    expect(util.formatAddress(
+      {address1: '123 Fake St', address2: 'Apt 1-D', city: '', state: 'NY', zip_code: '10001'}),
+    ).toBe('123 Fake St Apt 1-D, --, NY 10001');
+    expect(util.formatAddress(
+      {address1: '123 Fake St', address2: 'Apt 1-D', city: 'New York', state: '', zip_code: '10001'}),
+    ).toBe('123 Fake St Apt 1-D, New York, -- 10001');
+    expect(util.formatAddress(
+      {address1: '123 Fake St', address2: 'Apt 1-D', city: 'New York', state: 'NY', zip_code: ''}),
+    ).toBe('123 Fake St Apt 1-D, New York, NY --');
 
     const parsedAddressMultilineNull = util.formatAddressMultiline(null);
     expect(parsedAddressMultilineNull[0]).toBe(EMPTY_FIELD);
     expect(parsedAddressMultilineNull[1].type).toBe('br');
-    expect(parsedAddressMultilineNull[2]).toBe(EMPTY_FIELD);
-    expect(parsedAddressMultilineNull[3].type).toBe('br');
-    expect(parsedAddressMultilineNull[4]).toBe('-- --');
+    expect(parsedAddressMultilineNull[2]).toBe('--, -- --');
 
-    const parsedAddressMultilineFull = util.formatAddressMultiline({address1: '123 Fake St', address2: '', city: 'New York', state: 'NY', zip_code: '10001'});
+    const parsedAddressMultilineFull = util.formatAddressMultiline(
+      {address1: '123 Fake St', address2: '', city: 'New York', state: 'NY', zip_code: '10001'});
     expect(parsedAddressMultilineFull[0]).toBe('123 Fake St');
     expect(parsedAddressMultilineFull[1].type).toBe('br');
-    expect(parsedAddressMultilineFull[2]).toBe('New York');
-    expect(parsedAddressMultilineFull[3].type).toBe('br');
-    expect(parsedAddressMultilineFull[4]).toBe('NY 10001');
+    expect(parsedAddressMultilineFull[2]).toBe('New York, NY 10001');
   });
 
   it('Correctly formats an object as a URL param string', () => {


### PR DESCRIPTION
This brings it in line with the function being used in the Registry.