### PR TITLE
Add HTML string to HTML formatting util

### DIFF
--- a/src/formatting.tsx
+++ b/src/formatting.tsx
@@ -368,3 +368,7 @@ export function formatAddress(address?: IAddress | null) {
 export function formatAddressMultiline(address?: IAddress | null) {
   return parser(formatAddress(address).replace(', ', '<br/>'));
 }
+
+export function stringToHTML(string: string) {
+  return parser(string);
+}

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -312,16 +312,23 @@ describe('formatting', () => {
     expect(parsedHtml[2].type).toBe('br');
     expect(parsedHtml[3].type).toBe('br');
     expect(parsedHtml[4]).toBe('hello');
+    expect(util.parseAndPreserveNewlines('')).toBe(EMPTY_FIELD)
   });
 
   it('stringToHTML: converts HTML strings to HTML', () => {
-    const parsedHtml = util.stringToHTML('<div>hello<p>hello</p></div>') as JSX.Element[];
-    expect(parsedHtml[0].type).toBe('div');
-    expect(parsedHtml[1]).toBe('hello');
-    expect(parsedHtml[2].type).toBe('p');
-    expect(parsedHtml[3]).toBe('hello');
-    expect(parsedHtml[4].type).toBe('p');
-    expect(parsedHtml[5].type).toBe('div');
+    const parsedHtml = util.stringToHTML('<div>hello<p>hello</p></div>') as JSX.Element;
+
+    expect(parsedHtml.type).toBe('div');
+    expect(parsedHtml.props.children[0]).toBe('hello');
+    expect(parsedHtml.props.children[1].type).toBe('p');
+    expect(parsedHtml.props.children[1].props.children).toBe('hello');
+  });
+
+  it(`getDisplayName: returns a component's display name`, () => {
+    expect(util.getDisplayName({displayName: 'test name'})).toBe('test name');
+    expect(util.getDisplayName({name: 'test name'})).toBe('test name');
+    expect(util.getDisplayName({hello: 'hello'})).toBe('Component');
+    expect(util.getDisplayName('')).toBe(undefined);
   });
 
   it('formattedWebsite', () => {

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -314,6 +314,16 @@ describe('formatting', () => {
     expect(parsedHtml[4]).toBe('hello');
   });
 
+  it('stringToHTML: converts HTML strings to HTML', () => {
+    const parsedHtml = util.stringToHTML('<div>hello<p>hello</p></div>') as JSX.Element[];
+    expect(parsedHtml[0].type).toBe('div');
+    expect(parsedHtml[1]).toBe('hello');
+    expect(parsedHtml[2].type).toBe('p');
+    expect(parsedHtml[3]).toBe('hello');
+    expect(parsedHtml[4].type).toBe('p');
+    expect(parsedHtml[5].type).toBe('div');
+  });
+
   it('formattedWebsite', () => {
     const website = 'https://www.mighty.com',
       innerText = 'innerText';

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -312,7 +312,7 @@ describe('formatting', () => {
     expect(parsedHtml[2].type).toBe('br');
     expect(parsedHtml[3].type).toBe('br');
     expect(parsedHtml[4]).toBe('hello');
-    expect(util.parseAndPreserveNewlines('')).toBe(EMPTY_FIELD)
+    expect(util.parseAndPreserveNewlines('')).toBe(EMPTY_FIELD);
   });
 
   it('stringToHTML: converts HTML strings to HTML', () => {
@@ -325,9 +325,9 @@ describe('formatting', () => {
   });
 
   it(`getDisplayName: returns a component's display name`, () => {
-    expect(util.getDisplayName({displayName: 'test name'})).toBe('test name');
-    expect(util.getDisplayName({name: 'test name'})).toBe('test name');
-    expect(util.getDisplayName({hello: 'hello'})).toBe('Component');
+    expect(util.getDisplayName({ displayName: 'test name' })).toBe('test name');
+    expect(util.getDisplayName({ name: 'test name' })).toBe('test name');
+    expect(util.getDisplayName({ hello: 'hello' })).toBe('Component');
     expect(util.getDisplayName('')).toBe(undefined);
   });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -30,15 +30,15 @@ const TO_DISPLAY_ONLY: Array<[any, string]> = [
   [0.55, '55'],
 ];
 
-const INSERT_IF_TEST_CASES = [{ 1: true }, 'hello', 42, [1, 2, 3]]
+const INSERT_IF_TEST_CASES = [{ 1: true }, 'hello', 42, [1, 2, 3]];
 
 describe('utils', () => {
-  INSERT_IF_TEST_CASES.forEach((element) => {
+  INSERT_IF_TEST_CASES.forEach(element => {
     it('Correctly inserts element based on condition', () => {
       expect(util.insertIf(true, element)).toMatchObject([element]);
       expect(util.insertIf(false, element)).not.toMatchObject([element]);
-    })
-  })
+    });
+  });
 
   TEST_CASES.forEach(([value, display]) => {
     it(`Correctly converts percentage between '${value}' <=> '${display}'`, () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -30,7 +30,16 @@ const TO_DISPLAY_ONLY: Array<[any, string]> = [
   [0.55, '55'],
 ];
 
+const INSERT_IF_TEST_CASES = [{ 1: true }, 'hello', 42, [1, 2, 3]]
+
 describe('utils', () => {
+  INSERT_IF_TEST_CASES.forEach((element) => {
+    it('Correctly inserts element based on condition', () => {
+      expect(util.insertIf(true, element)).toMatchObject([element]);
+      expect(util.insertIf(false, element)).not.toMatchObject([element]);
+    })
+  })
+
   TEST_CASES.forEach(([value, display]) => {
     it(`Correctly converts percentage between '${value}' <=> '${display}'`, () => {
       expect(util.getPercentValue(display)).toBe(value);


### PR DESCRIPTION
Add function to take a string containing HTML `('<div>hello</div>')` and return it as HTML

**Test Results:**
<img width="707" alt="Screen Shot 2020-11-04 at 3 22 56 PM" src="https://user-images.githubusercontent.com/46094451/98164072-bdf61d80-1eb1-11eb-9b20-0625b111fb77.png">

**Lint Results:**
<img width="760" alt="Screen Shot 2020-11-04 at 3 23 16 PM" src="https://user-images.githubusercontent.com/46094451/98164097-c64e5880-1eb1-11eb-8523-2bbd1a6709ee.png">
