### PR TITLE
Add datetime format options

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,10 +2,10 @@ import Decimal from 'decimal.js';
 
 export const EMPTY_FIELD = '--';
 
-export const DATE_FORMATS: { date: string; date_at_time: string; date_value: string } = {
+export const DATE_FORMATS: { date: string; date_value: string; time: string; } = {
   date: 'MM/DD/YY',
-  date_at_time: 'MM/DD/YY @ h:mmA', // ex. 07/14/16 @ 2:24PM
   date_value: 'YYYY-MM-DD',
+  time: 'h:mmA', // ex. 2:24PM
 };
 
 export const CENT_DECIMAL = new Decimal('100');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@ import Decimal from 'decimal.js';
 
 export const EMPTY_FIELD = '--';
 
-export const DATE_FORMATS: { date: string; date_value: string; time: string; } = {
+export const DATE_FORMATS: { date: string; date_value: string; time: string } = {
   date: 'MM/DD/YY',
   date_value: 'YYYY-MM-DD',
   time: 'h:mmA', // ex. 2:24PM

--- a/src/formatting.tsx
+++ b/src/formatting.tsx
@@ -113,7 +113,7 @@ export function formatDateTime(value?: string | null, symbol: string = '@') {
   if (!hasStringContent(value)) {
     return EMPTY_FIELD;
   }
-  return `${formatDate(value, DATE_FORMATS.date)} ${symbol} ${formatDate(value, DATE_FORMATS.time)}`
+  return `${formatDate(value, DATE_FORMATS.date)} ${symbol} ${formatDate(value, DATE_FORMATS.time)}`;
 }
 
 export function getNameOrDefault(obj?: unknown, { field = 'name', defaultValue = EMPTY_FIELD } = {}) {

--- a/src/formatting.tsx
+++ b/src/formatting.tsx
@@ -110,6 +110,9 @@ export function formatDate(value?: string | null, dateFormat = DATE_FORMATS.date
 }
 
 export function formatDateTime(value?: string | null, symbol: string = '@') {
+  if (!hasStringContent(value)) {
+    return EMPTY_FIELD;
+  }
   return `${formatDate(value, DATE_FORMATS.date)} ${symbol} ${formatDate(value, DATE_FORMATS.time)}`
 }
 

--- a/src/formatting.tsx
+++ b/src/formatting.tsx
@@ -109,8 +109,8 @@ export function formatDate(value?: string | null, dateFormat = DATE_FORMATS.date
   return dateFnsFormat(value, dateFormat);
 }
 
-export function formatDateTime(value?: string | null) {
-  return formatDate(value, DATE_FORMATS.date_at_time);
+export function formatDateTime(value?: string | null, symbol: string = '@') {
+  return `${formatDate(value, DATE_FORMATS.date)} ${symbol} ${formatDate(value, DATE_FORMATS.time)}`
 }
 
 export function getNameOrDefault(obj?: unknown, { field = 'name', defaultValue = EMPTY_FIELD } = {}) {

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -220,6 +220,7 @@ describe('formatting', () => {
 
   it('formatDateTime', () => {
     expect(util.formatDateTime('2008-09-22T13:57:31.2311892')).toBe('09/22/08 @ 1:57PM');
+    expect(util.formatDateTime('2008-09-22T13:57:31.2311892', 'at')).toBe('09/22/08 at 1:57PM');
   });
 
   it('mapBooleanToText: Maps booleans to yes and no', () => {


### PR DESCRIPTION
**Description:** Add ability to custom format a date-time with a second argument to `formatDateTime`

**Purpose:** To have flexibility matching mocks dealing with timestamps

examples:
`formatDateTime(datetime)` --> `<date> @ <time>` (default)
`formatDateTime(datetime, 'at')` --> `<date> at <time>`
